### PR TITLE
chore(startup.sh): Cancel the -x default startup option

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -74,4 +74,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -u chrony -d -x -L ${LOG_LEVEL}
+exec /usr/sbin/chronyd -u chrony -d -L ${LOG_LEVEL} $@


### PR DESCRIPTION
1、Cancel the -x default startup option
2、Support for specifying the chronyd service option parameter on startup