### PR TITLE
Update image to be non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY --chmod=0755 assets/startup.sh /bin/startup
 EXPOSE 123/udp
 
 # marking volumes that need to be writable
+# this will also create unnamed volumes on the host system
 VOLUME /etc/chrony /run/chrony /var/lib/chrony
 
 # let docker know how to test container health

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache chrony tzdata && \
     chmod 1750 /var/lib/chrony
 
 # script to configure/startup chrony (ntp)
-COPY assets/startup.sh /bin/startup
+COPY --chmod=0755 assets/startup.sh /bin/startup
 
 # ntp port
 EXPOSE 123/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,13 @@ ENV NTP_DIRECTIVES="ratelimit\nrtcsync"
 
 # install chrony
 RUN apk add --no-cache chrony tzdata && \
-    rm /etc/chrony/chrony.conf
+    rm /etc/chrony/chrony.conf && \
+    chmod 1750 /etc/chrony && \
+    mkdir /run/chrony && \
+    chown -R chrony:chrony /run/chrony && \
+    chmod 1750 /run/chrony && \
+    chown -R chrony:chrony /var/lib/chrony && \
+    chmod 1750 /var/lib/chrony
 
 # script to configure/startup chrony (ntp)
 COPY assets/startup.sh /bin/startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,5 @@ VOLUME /etc/chrony /run/chrony /var/lib/chrony
 HEALTHCHECK CMD chronyc -n tracking || exit 1
 
 # start chronyd in the foreground
+USER chrony:chrony
 ENTRYPOINT [ "/bin/startup" ]

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ $> docker run --name=ntp            \
               simonrupf/chronyd
 
 # OR run ntp with higher security
-$> docker run --name=ntp                           \
-              --restart=always                     \
-              --detach                             \
-              --publish=123:123/udp                \
-              --read-only                          \
-              --tmpfs=/etc/chrony:rw,mode=1750     \
-              --tmpfs=/run/chrony:rw,mode=1750     \
-              --tmpfs=/var/lib/chrony:rw,mode=1750 \
+$> docker run --name=ntp                                           \
+              --restart=always                                     \
+              --detach                                             \
+              --publish=123:123/udp                                \
+              --read-only                                          \
+              --tmpfs=/etc/chrony:rw,mode=1750,uid=100,gid=101     \
+              --tmpfs=/run/chrony:rw,mode=1750,uid=100,gid=101     \
+              --tmpfs=/var/lib/chrony:rw,mode=1750,uid=100,gid=101 \
               simonrupf/chronyd
 ```
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,7 +1,46 @@
 #!/bin/sh
+set -eu
+
+## Script will be run as chrony user !
 
 DEFAULT_NTP="0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org"
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
+
+echo "
+-------------------------------------
+ℹ️ Container Information
+-------------------------------------
+OS:            $(. /etc/os-release; echo "${PRETTY_NAME}")
+Docker user:   $(whoami)
+Docker uid:    $(id -u)
+Docker gid:    $(id -g)
+"
+
+CURRENT_USERGROUP="$(id -u):$(id -g)"
+CHRONY_USERGROUP="$(id -u chrony):$(id -g chrony)"
+
+if [ "$CURRENT_USERGROUP" != "$CHRONY_USERGROUP" ]; then
+  echo "[WARNING] Container running under a different user than recommended!"
+  echo ""
+fi
+
+# Check if existing volumes/folders are writable
+if [ ! -w "/etc/chrony" ] || [ ! -w "/run/chrony" ] || [ ! -w "/var/lib/chrony" ]; then
+  echo "
+It seems that the necessary folders are not writable by the container user ($CURRENT_USERGROUP).
+As this container is running as non-root, it cannot fix the permissions it self.
+
+Please remove the volumes or update them to be writable by $CURRENT_USERGROUP.
+Or run the container with 'user: \"0:0\"' so it will ran as root so it can fix itself.
+
+If using tmpfs update the config to:
+tmpfs:
+  - /etc/chrony:rw,mode=1750,uid=100,gid=101
+  - /run/chrony:rw,mode=1750,uid=100,gid=101
+  - /var/lib/chrony:rw,mode=1750,uid=100,gid=101
+"
+  exit 1
+fi
 
 # confirm correct permissions on chrony run directory
 if [ -d /run/chrony ]; then

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -131,4 +131,4 @@ if [[ "${ENABLE_SYSCLK:-false}" = true ]]; then
 fi
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -u chrony -d ${SYSCLK} -L ${LOG_LEVEL}
+exec /usr/sbin/chronyd -U -u chrony -d ${SYSCLK} -L ${LOG_LEVEL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.9'
-
+---
 services:
   ntp:
     build: .
@@ -8,9 +7,9 @@ services:
     restart: always
     read_only: true
     tmpfs:
-      - /etc/chrony:rw,mode=1750
-      - /run/chrony:rw,mode=1750
-      - /var/lib/chrony:rw,mode=1750
+      - /etc/chrony:rw,mode=1750,uid=100,gid=101
+      - /run/chrony:rw,mode=1750,uid=100,gid=101
+      - /var/lib/chrony:rw,mode=1750,uid=100,gid=101
     ports:
       - 123:123/udp
 #    cap_add:

--- a/run.sh
+++ b/run.sh
@@ -25,20 +25,20 @@ function start_container() {
     echo "SYSCLK requested, adding SYS_TIME capability..."
     DOCKER_OPTS="${DOCKER_OPTS} --cap-add=SYS_TIME"
   fi
-  $DOCKER run --name=${CONTAINER_NAME}             \
-              --detach=true                        \
-              --restart=always                     \
-              --publish=123:123/udp                \
-              --env=NTP_SERVERS=${NTP_SERVERS}     \
-              --env=ENABLE_NTS=${ENABLE_NTS}       \
-              --env=ENABLE_SYSCLK=${ENABLE_SYSCLK} \
-              --env=NOCLIENTLOG=${NOCLIENTLOG}     \
-              --env=LOG_LEVEL=${LOG_LEVEL}         \
-              --read-only=true                     \
-              --tmpfs=/etc/chrony:rw,mode=1750     \
-              --tmpfs=/run/chrony:rw,mode=1750     \
-              --tmpfs=/var/lib/chrony:rw,mode=1750 \
-              ${DOCKER_OPTS}                       \
+  $DOCKER run --name=${CONTAINER_NAME}                             \
+              --detach=true                                        \
+              --restart=always                                     \
+              --publish=123:123/udp                                \
+              --env=NTP_SERVERS=${NTP_SERVERS}                     \
+              --env=ENABLE_NTS=${ENABLE_NTS}                       \
+              --env=ENABLE_SYSCLK=${ENABLE_SYSCLK}                 \
+              --env=NOCLIENTLOG=${NOCLIENTLOG}                     \
+              --env=LOG_LEVEL=${LOG_LEVEL}                         \
+              --read-only=true                                     \
+              --tmpfs=/etc/chrony:rw,mode=1750,uid=100,gid=101     \
+              --tmpfs=/run/chrony:rw,mode=1750,uid=100,gid=101     \
+              --tmpfs=/var/lib/chrony:rw,mode=1750,uid=100,gid=101 \
+              ${DOCKER_OPTS}                                       \
               ${IMAGE_NAME}:latest > /dev/null
 }
 


### PR DESCRIPTION
Hi there!

I'm loving the image, and this is just an addition to make it a bit more secure.
However, please feel free to just ignore this PR and close it. No hard feelings here.

The main goal is to get the image running under the Chrony user. 
The current container still started with root and then ran Chrony as a user. This means that the process technically still ran as root.

I have tried to help the user by adding startup comments if something is wrong and how to fix it.
If the user has existing containers and volumes, it is possible that the container will not start again due to the permission change.

I've tried to be descriptive with the commit messages, so reviewing per commit would be the best way.
