### PR TITLE
Update GitHub docker building workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "docker" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,51 +1,59 @@
+---
 name: Deploy multi-architecture Docker images with buildx
 
 on:
   pull_request:
-    branches: master
+    branches:
+      - "master"
   push:
-    branches: master
-    tags: '*'
+    branches:
+      - "master"
+    tags:
+      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   buildx:
+    # This workflow is only of value for simonrupf/docker-chronyd repo and would always be skipped in forks
+    if: github.repository == 'simonrupf/docker-chronyd'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Prepare
-        id: prepare
-        run: |
-          IMAGE=simonrupf/chronyd
-          QEMU_PLATFORMS=linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
-          VERSION=${GITHUB_REF##*/}
-          echo "buildx_args=--tag ${IMAGE}:latest \
-            --tag ${IMAGE}:${VERSION} \
-            --platform linux/amd64,linux/386,${QEMU_PLATFORMS} ."  >> $GITHUB_OUTPUT
-          echo "qemu_platforms=${QEMU_PLATFORMS}" >> $GITHUB_OUTPUT
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
         with:
-          platforms: ${{ steps.prepare.outputs.qemu_platforms }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+          persist-credentials: false # Do not store the token or SSH key with the local git config
+      - # we need qemu and buildx so we can build multiple platforms later
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+      - # BuildKit (used with `docker buildx`) is the best way to build images
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
         with:
-          install: true
-      - name: Docker Build
-        run: |
-          docker build --no-cache --pull --output "type=image,push=false" --build-arg BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%S%z') ${{ steps.prepare.outputs.buildx_args }}
-      - name: Docker Login
-        if: success() && github.event_name != 'pull_request' && github.ref != 'refs/heads/master'
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          printenv DOCKER_PASSWORD | docker login --username "${DOCKER_USERNAME}" --password-stdin
-      - name: Docker Push
-        if: success() && github.event_name != 'pull_request' && github.ref != 'refs/heads/master'
-        run: |
-          docker build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
-      - name: Cleanup
-        if: always() && github.event_name != 'pull_request' && github.ref != 'refs/heads/master'
-        run: |
-          rm -f ${HOME}/.docker/config.json
+          # list of Docker images to use as base name for tags
+          images: simonrupf/chronyd
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # used on a tag event
+            type=ref,event=tag
+      - name: Login to DockerHub
+        if: success() && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'dependabot') }}


### PR DESCRIPTION
Hi there,

Please feel free to just ignore this PR and close it. No hard feelings here.

I've updated your workflow to be more in line with docker image generation. Let the `docker/` do the hard work for you.

First, only run on your repo, not on forks. Forks do not have the required credentials for logging in and pushing anyway. Sure, we could move it to just prevent the docker login and docker push, let me know if that is what you want. Personally, skip it all together, it also means no wasted runner minutes.

Secondly, use the `docker/metadata-action` workflows` this one is amazing in generating all the options you would love to have. Including [opencontainer labels](https://specs.opencontainers.org/image-spec/annotations/). This allows third-party tooling to easily find where and when the image was built.

Thirdly, some security stuff, let Dependabot notify you on updates to workflows. Also lock down the GITHUB_TOKEN in the runner to just the `contents read`.

To be fair, the build workflow should work as it is presented here. But it could be that is need a bit of change after the PR is merged. Hopefully not though! I'm using, sort of, the same workflow for other projects. But I've adapted it to your repo.